### PR TITLE
Wrench support

### DIFF
--- a/etasl_ros_controllers/include/etasl_ros_controllers/etasl_driver.h
+++ b/etasl_ros_controllers/include/etasl_ros_controllers/etasl_driver.h
@@ -36,6 +36,7 @@ typedef std::vector<std::string> StringVector;
 using VectorMap = std::map<std::string, Vector>;
 using RotationMap = std::map<std::string, Rotation>;
 using TwistMap = std::map<std::string, Twist>;
+using WrenchMap = std::map<std::string, Wrench>;
 
 class EtaslDriver
 {
@@ -99,6 +100,7 @@ public:
   int setInput(const RotationMap& rmap);
   int setInput(const VectorMap& fmap);
   int setInput(const TwistMap& tmap);
+  int setInput(const WrenchMap& tmap);
 
   /**
    * sets all (scalar) variables with the velocity specified in the map as input variable

--- a/etasl_ros_controllers/include/etasl_ros_controllers/etasl_example_controller.h
+++ b/etasl_ros_controllers/include/etasl_ros_controllers/etasl_example_controller.h
@@ -38,6 +38,7 @@ using FrameMap = std::map<std::string, Frame>;
 using VectorMap = std::map<std::string, Vector>;
 using RotationMap = std::map<std::string, Rotation>;
 using TwistMap = std::map<std::string, Twist>;
+using WrenchMap = std::map<std::string, Wrench>;
 
 class EtaslController
   : public controller_interface::MultiInterfaceController<hardware_interface::PositionJointInterface>
@@ -93,6 +94,11 @@ private:
   size_t n_twist_inputs_{};
   std::vector<std::string> twist_input_names_;
   std::vector<boost::shared_ptr<realtime_tools::RealtimeBuffer<geometry_msgs::Twist>>> twist_input_buffers_;
+
+  WrenchMap wrench_input_map_;
+  size_t n_wrench_inputs_{};
+  std::vector<std::string> wrench_input_names_;
+  std::vector<boost::shared_ptr<realtime_tools::RealtimeBuffer<geometry_msgs::Wrench>>> wrench_input_buffers_;
 
   // Outputs
   DoubleMap output_map_;

--- a/etasl_ros_controllers/src/etasl_driver.cpp
+++ b/etasl_ros_controllers/src/etasl_driver.cpp
@@ -154,6 +154,23 @@ int EtaslDriver::setInput(const TwistMap& tmap)
   return 0;
 }
 
+int EtaslDriver::setInput(const WrenchMap& tmap)
+{
+  for (auto item : tmap)
+  {
+    auto v = ctx_->getInputChannel<Wrench>(item.first);
+    if (v)
+    {
+      v->setValue(item.second);
+    }
+    else
+    {
+      return -1;
+    }
+  }
+  return 0;
+}
+
 int EtaslDriver::setInput(const VectorMap& vmap)
 {
   for (auto item : vmap)

--- a/etasl_ros_controllers/src/etasl_example_controller.cpp
+++ b/etasl_ros_controllers/src/etasl_example_controller.cpp
@@ -176,6 +176,17 @@ bool EtaslController::configureInput(ros::NodeHandle& node_handle)
         twist_input_buffers_.push_back(input_buffer);
         ++n_twist_inputs_;
       }
+      else if (input_types_[i] == "Wrench")
+      {
+	ROS_INFO_STREAM("EtaslController: Adding input channel \"" << input_names_[i] << "\" of type \"Twist\"");
+	wrench_input_names_.push_back(input_names_[i]);
+	auto input_buffer = boost::make_shared<realtime_tools::RealtimeBuffer<geometry_msgs::Wrench>>();
+	boost::function<void(const geometry_msgs::WrenchConstPtr&)> callback =
+	  [input_buffer](const geometry_msgs::WrenchConstPtr& msg) { input_buffer->writeFromNonRT(*msg); };
+	subs_.push_back(node-handle.subscribe<geometry_msgs::Wrench>(input_names_[i], 1, callback));
+	wrench_input_buffers_.push_back(input_buffer);
+	++n_wrench_inputs_;
+      }
       else
       {
         ROS_ERROR_STREAM("EtaslController: Input channel type \"" << input_types_[i] << "\" is not supported");
@@ -244,6 +255,16 @@ void EtaslController::getInput()
       twist_input_map_["global." + twist_input_names_[i]] = twist;
     }
     etasl_->setInput(twist_input_map_);
+  }
+  if (n_wrench_inputs_ > 0)
+  {
+    for (size_t i = 0; i < n_wrench_inputs_; i++)
+    {
+      Wrench wrench;
+      tf::wrenchMsgToKDL(*wrench_input_buffers_[i]->readFromRT(), wrench);
+      wrench_input_map["global." + wrench_input_names_[i]] = wrench;
+    }
+    etasl_->setInput(wrench_input_map_);
   }
 }
 

--- a/etasl_ros_controllers/src/etasl_example_controller.cpp
+++ b/etasl_ros_controllers/src/etasl_example_controller.cpp
@@ -178,14 +178,14 @@ bool EtaslController::configureInput(ros::NodeHandle& node_handle)
       }
       else if (input_types_[i] == "Wrench")
       {
-	ROS_INFO_STREAM("EtaslController: Adding input channel \"" << input_names_[i] << "\" of type \"Twist\"");
-	wrench_input_names_.push_back(input_names_[i]);
-	auto input_buffer = boost::make_shared<realtime_tools::RealtimeBuffer<geometry_msgs::Wrench>>();
-	boost::function<void(const geometry_msgs::WrenchConstPtr&)> callback =
-	  [input_buffer](const geometry_msgs::WrenchConstPtr& msg) { input_buffer->writeFromNonRT(*msg); };
-	subs_.push_back(node-handle.subscribe<geometry_msgs::Wrench>(input_names_[i], 1, callback));
-	wrench_input_buffers_.push_back(input_buffer);
-	++n_wrench_inputs_;
+	      ROS_INFO_STREAM("EtaslController: Adding input channel \"" << input_names_[i] << "\" of type \"Twist\"");
+	      wrench_input_names_.push_back(input_names_[i]);
+	      auto input_buffer = boost::make_shared<realtime_tools::RealtimeBuffer<geometry_msgs::Wrench>>();
+	      boost::function<void(const geometry_msgs::WrenchConstPtr&)> callback =
+	          [input_buffer](const geometry_msgs::WrenchConstPtr& msg) { input_buffer->writeFromNonRT(*msg); };
+	      subs_.push_back(node_handle.subscribe<geometry_msgs::Wrench>(input_names_[i], 1, callback));
+	      wrench_input_buffers_.push_back(input_buffer);
+	      ++n_wrench_inputs_;
       }
       else
       {
@@ -262,7 +262,7 @@ void EtaslController::getInput()
     {
       Wrench wrench;
       tf::wrenchMsgToKDL(*wrench_input_buffers_[i]->readFromRT(), wrench);
-      wrench_input_map["global." + wrench_input_names_[i]] = wrench;
+      wrench_input_map_["global." + wrench_input_names_[i]] = wrench;
     }
     etasl_->setInput(wrench_input_map_);
   }


### PR DESCRIPTION
Added support for wrenches as inputs. This was missing in `etasl_rtt`, but was added in [commit 38b31085](https://gitlab.mech.kuleuven.be/rob-expressiongraphs/etasl_rtt/commit/38b31085ec6fa8e36d8b2d6585e5a3bb32dc5188). Might be beneficial to add here too if we're starting force control soon. 