### PR TITLE
Event monitoring

### DIFF
--- a/etasl_ros_control_examples/config/hardware_controllers_kuka_monitors.yaml
+++ b/etasl_ros_control_examples/config/hardware_controllers_kuka_monitors.yaml
@@ -1,0 +1,36 @@
+#Publish all joint states
+joint_state_controller:
+  type: joint_state_controller/JointStateController
+  publish_rate: 50
+
+# eTaSl example controller
+etasl_controller:
+  type: "etasl_ros_controllers/EtaslController"
+  joints:
+    - joint_a1
+    - joint_a2
+    - joint_a3
+    - joint_a4
+    - joint_a5
+    - joint_a6
+  input:
+    names:
+      - "tgt_x"
+      - "tgt_y"
+      - "tgt_z"
+    types:
+      - "Scalar"
+      - "Scalar"
+      - "Scalar"
+  output:
+    names:
+      - "error_x"
+      - "error_y"
+      - "error_z"
+      - "laser"
+    types:
+      - "Scalar"
+      - "Scalar"
+      - "Scalar"
+      - "Vector"
+  task_specification: "$(find etasl_ros_control_examples)/scripts/example_kuka_monitors.lua"

--- a/etasl_ros_control_examples/launch/example_kuka_monitors.launch
+++ b/etasl_ros_control_examples/launch/example_kuka_monitors.launch
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<launch>
+    <arg name="sim" default="true"/>
+
+    <include file="$(find kuka_kr6_support)/launch/load_kr6r900sixx.launch"/>
+
+    <rosparam file="$(find kuka_rsi_hw_interface)/config/controller_joint_names.yaml" command="load"/>
+    <rosparam file="$(find kuka_rsi_hw_interface)/test/test_params_sim.yaml" command="load" if="$(arg sim)"/>
+    <rosparam file="$(find kuka_rsi_hw_interface)/test/test_params.yaml" command="load" unless="$(arg sim)"/>
+    <node name="kuka_hardware_interface" pkg="kuka_rsi_hw_interface" type="kuka_hardware_interface_node" respawn="false" output="screen" required="true"/>
+
+    <rosparam file="$(find etasl_ros_control_examples)/config/hardware_controllers_kuka_monitors.yaml" command="load" subst_value="true"/>
+    <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false" output="screen" args="etasl_controller joint_state_controller"/>
+
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher"/>
+
+    <node name='kuka_rsi_simulator' pkg='kuka_rsi_simulator' type="kuka_rsi_simulator" args="127.0.0.1 49152" if="$(arg sim)"/>
+
+    <node name="rviz" pkg="rviz" type="rviz" args="-d $(find industrial_robot_client)/config/robot_state_visualize.rviz" required="true"/>
+
+    <node name="target_publisher" pkg="etasl_ros_control_examples" type="target_publisher.py" required="true"/>
+</launch>

--- a/etasl_ros_control_examples/scripts/example_kuka_monitors.lua
+++ b/etasl_ros_control_examples/scripts/example_kuka_monitors.lua
@@ -1,0 +1,94 @@
+-- Copyright (c) 2019 Norwegian University of Science and Technology
+-- Use of this source code is governed by the LGPL-3.0 license, see LICENSE
+
+require("context")
+require("geometric")
+
+local u = UrdfExpr()
+u:readFromParam("/robot_description")
+u:addTransform("ee", "tool0", "base_link")
+
+local r = u:getExpressions(ctx)
+
+-- The transformation of the robot mounting plate frame with respect to the robot base frame
+robot_ee = r.ee
+
+-- The name of the robot joints
+robot_joints = {
+    "joint_a1",
+    "joint_a2",
+    "joint_a3",
+    "joint_a4",
+    "joint_a5",
+    "joint_a6"
+}
+
+maxvel = 0.3
+for i = 1, #robot_joints do
+    BoxConstraint{
+        context = ctx,
+        var_name = robot_joints[i],
+        lower = -maxvel,
+        upper = maxvel
+    }
+end
+
+tgt_x = ctx:createInputChannelScalar("tgt_x")
+tgt_y = ctx:createInputChannelScalar("tgt_y")
+tgt_z = ctx:createInputChannelScalar("tgt_z")
+
+d = Variable{context = ctx, name = "d", vartype = "feature"}
+
+Constraint{
+    context = ctx,
+    name = "laserdistance",
+    expr = d,
+    target_lower = 0.5,
+    target_upper = 0.9,
+    K = 4
+}
+
+laserspot = robot_ee * vector(0, 0, d)
+
+Constraint{
+    context = ctx,
+    name = "x",
+    expr = tgt_x - coord_x(laserspot),
+    priority = 2,
+    K = 4
+}
+Constraint{
+    context = ctx,
+    name = "y",
+    expr = tgt_y - coord_y(laserspot),
+    priority = 2,
+    K = 4
+}
+Constraint{
+    context = ctx,
+    name = "z",
+    expr = tgt_z - coord_z(laserspot),
+    priority = 2,
+    K = 4
+}
+
+Monitor{
+        context=ctx,
+        name="signal_time",
+        upper=0.0,
+        actionname="event",
+	argument="ten_seconds",
+        expr=time-constant(10)
+}
+
+Monitor{
+        context=ctx,
+        name="finish_after_motion",
+        upper=0.0,
+        actionname="exit",
+        expr=time-constant(30)
+}
+ctx:setOutputExpression("error_x", coord_x(laserspot) - tgt_x)
+ctx:setOutputExpression("error_y", coord_y(laserspot) - tgt_y)
+ctx:setOutputExpression("error_z", coord_z(laserspot) - tgt_z)
+ctx:setOutputExpression("laser", laserspot)

--- a/etasl_ros_controllers/CMakeLists.txt
+++ b/etasl_ros_controllers/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
   dynamic_reconfigure
   kdl_conversions
   geometry_msgs
+  std_msgs
   hardware_interface
   message_generation
   pluginlib
@@ -44,6 +45,7 @@ catkin_package(
     dynamic_reconfigure
     kdl_conversions
     geometry_msgs
+    std_msgs
     hardware_interface
     message_runtime
     pluginlib
@@ -54,6 +56,7 @@ catkin_package(
 add_library(etasl_ros_controllers
   src/etasl_driver.cpp
   src/etasl_example_controller.cpp
+  src/topic_observer.cpp
 )
 
 # add_dependencies(franka_example_controllers

--- a/etasl_ros_controllers/include/etasl_ros_controllers/etasl_driver.h
+++ b/etasl_ros_controllers/include/etasl_ros_controllers/etasl_driver.h
@@ -43,7 +43,6 @@ class EtaslDriver
   boost::shared_ptr<qpOASESSolver> solver_;
   bool etaslread;
   bool initialized_;
-  boost::shared_ptr<Context> ctx_;
   boost::shared_ptr<LuaContext> lua;
   boost::shared_ptr<Observer> obs_;
   boost::shared_ptr<OutputGenerator> out_;
@@ -74,6 +73,7 @@ class EtaslDriver
                                   double convergence_crit);
 
 public:
+  boost::shared_ptr<Context> ctx_;
   /**
    * eTaSLCppDriver constructor
    *

--- a/etasl_ros_controllers/include/etasl_ros_controllers/etasl_driver.h
+++ b/etasl_ros_controllers/include/etasl_ros_controllers/etasl_driver.h
@@ -36,6 +36,7 @@ typedef std::vector<std::string> StringVector;
 using VectorMap = std::map<std::string, Vector>;
 using RotationMap = std::map<std::string, Rotation>;
 using TwistMap = std::map<std::string, Twist>;
+using WrenchMap = std::map<std::string, Wrench>;
 
 class EtaslDriver
 {
@@ -99,6 +100,7 @@ public:
   int setInput(const RotationMap& rmap);
   int setInput(const VectorMap& fmap);
   int setInput(const TwistMap& tmap);
+  int setInput(const WrenchMap& tmap);
 
   /**
    * sets all (scalar) variables with the velocity specified in the map as input variable

--- a/etasl_ros_controllers/include/etasl_ros_controllers/etasl_example_controller.h
+++ b/etasl_ros_controllers/include/etasl_ros_controllers/etasl_example_controller.h
@@ -29,6 +29,7 @@
 #include <expressiongraph/context_scripting.hpp>
 
 #include <etasl_ros_controllers/etasl_driver.h>
+#include <etasl_ros_controllers/topic_observer.h>
 
 using namespace KDL;
 
@@ -130,6 +131,8 @@ private:
   TwistMap twist_output_map_;
   size_t n_twist_outputs_{};
   std::vector<boost::shared_ptr<realtime_tools::RealtimePublisher<geometry_msgs::Twist>>> twist_realtime_pubs_;
+
+  boost::shared_ptr<realtime_tools::RealtimePublisher<std_msgs::String>> event_pub_p_;
 
   std::string task_specification_;
   boost::shared_ptr<EtaslDriver> etasl_;

--- a/etasl_ros_controllers/include/etasl_ros_controllers/etasl_example_controller.h
+++ b/etasl_ros_controllers/include/etasl_ros_controllers/etasl_example_controller.h
@@ -38,6 +38,7 @@ using FrameMap = std::map<std::string, Frame>;
 using VectorMap = std::map<std::string, Vector>;
 using RotationMap = std::map<std::string, Rotation>;
 using TwistMap = std::map<std::string, Twist>;
+using WrenchMap = std::map<std::string, Wrench>;
 
 class EtaslController
   : public controller_interface::MultiInterfaceController<hardware_interface::PositionJointInterface>
@@ -93,6 +94,11 @@ private:
   size_t n_twist_inputs_{};
   std::vector<std::string> twist_input_names_;
   std::vector<boost::shared_ptr<realtime_tools::RealtimeBuffer<geometry_msgs::Twist>>> twist_input_buffers_;
+
+  WrenchMap wrench_input_map_;
+  size_t n_wrench_inputs_{};
+  std::vector<std::string> wrench_input_names_;
+  std::vector<boost::shared_ptr<realtime_tools::RealtimeBuffer<geometry_msgs::Wrench>>> wrench_input_buffers_;
 
   // Outputs
   DoubleMap output_map_;

--- a/etasl_ros_controllers/include/etasl_ros_controllers/topic_observer.h
+++ b/etasl_ros_controllers/include/etasl_ros_controllers/topic_observer.h
@@ -1,0 +1,41 @@
+// Copyright (c) 2019 Norwegian University of Science and Technology
+// Use of this source code is governed by the LGPL-3.0 license, see LICENSE
+
+/*
+ * Author: Mathias Hauan Arbo
+ *
+ * This file has been adapted from:
+ * https://gitlab.mech.kuleuven.be/rob-expressiongraphs/etasl_rtt/blob/master/src/port_observer.hpp
+ */
+#pragma once
+
+#include <expressiongraph/context.hpp>
+#include <ros/ros.h>
+#include <realtime_tools/realtime_publisher.h>
+#include <std_msgs/String.h>
+#include <string>
+
+namespace KDL {
+
+/**
+ * Creates an observer that maps a trigger of a monitor in eTaSL to
+ * a string on a ros topic.
+ * \param _ctx [in] context, when exit_when_triggered==true, then setFinishStatus() is called 
+ *             on _ctx when an event is triggered.
+ * \param _outp [in] the ROS publisher to publish the event.
+ * \param _action_name [in] should match the  action_name that is specified in the monitor 
+ * \param _exit_when_triggered [in] when true, the triggered monitor will also cause the component to 
+ *        stop.
+ * \param _next  [in] points to the next handler for an observer.
+ */
+Observer::Ptr create_topic_observer(
+    Context::Ptr _ctx,
+    boost::shared_ptr<realtime_tools::RealtimePublisher<std_msgs::String>> _outp,
+    const std::string& _action_name,
+    const std::string& _event_postfix,
+    bool  _exit_when_triggered,
+    Observer::Ptr _next = Observer::Ptr()
+);
+
+} // namespace KDL
+

--- a/etasl_ros_controllers/package.xml
+++ b/etasl_ros_controllers/package.xml
@@ -21,6 +21,7 @@
   <depend>dynamic_reconfigure</depend>
   <depend>kdl_conversions</depend>
   <depend>geometry_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>realtime_tools</depend>

--- a/etasl_ros_controllers/src/etasl_driver.cpp
+++ b/etasl_ros_controllers/src/etasl_driver.cpp
@@ -154,6 +154,23 @@ int EtaslDriver::setInput(const TwistMap& tmap)
   return 0;
 }
 
+int EtaslDriver::setInput(const WrenchMap& tmap)
+{
+  for (auto item : tmap)
+  {
+    auto v = ctx_->getInputChannel<Wrench>(item.first);
+    if (v)
+    {
+      v->setValue(item.second);
+    }
+    else
+    {
+      return -1;
+    }
+  }
+  return 0;
+}
+
 int EtaslDriver::setInput(const VectorMap& vmap)
 {
   for (auto item : vmap)

--- a/etasl_ros_controllers/src/etasl_example_controller.cpp
+++ b/etasl_ros_controllers/src/etasl_example_controller.cpp
@@ -176,6 +176,17 @@ bool EtaslController::configureInput(ros::NodeHandle& node_handle)
         twist_input_buffers_.push_back(input_buffer);
         ++n_twist_inputs_;
       }
+      else if (input_types_[i] == "Wrench")
+      {
+	ROS_INFO_STREAM("EtaslController: Adding input channel \"" << input_names_[i] << "\" of type \"Twist\"");
+	wrench_input_names_.push_back(input_names_[i]);
+	auto input_buffer = boost::make_shared<realtime_tools::RealtimeBuffer<geometry_msgs::Wrench>>();
+	boost::function<void(const geometry_msgs::WrenchConstPtr&)> callback =
+	  [input_buffer](const geometry_msgs::WrenchConstPtr& msg) { input_buffer->writeFromNonRT(*msg); };
+	subs_.push_back(node-handle.subscribe<geometry_msgs::Wrench>(input_names_[i], 1, callback));
+	wrench_input_buffers_.push_back(input_buffer);
+	++n_wrench_inputs_;
+      }
       else
       {
         ROS_ERROR_STREAM("EtaslController: Input channel type \"" << input_types_[i] << "\" is not supported");
@@ -244,6 +255,16 @@ void EtaslController::getInput()
       twist_input_map_["global." + twist_input_names_[i]] = twist;
     }
     etasl_->setInput(twist_input_map_);
+  }
+  if (n_wrench_inputs_ > 0)
+  {
+    for (size_t i = 0; i < n_wrench_inputs_; i++)
+    {
+      Wrench wrench;
+      tf::wrenchMsgToKDL(*wrench_input_buffers_[i]->readFromRT(), wrench);
+      wrench_input_map["global." + wrench_input_names_[i]] = wrench;
+    }
+    etasl_->setInput(wrench_input_map_);
   }
 }
 

--- a/etasl_ros_controllers/src/etasl_example_controller.cpp
+++ b/etasl_ros_controllers/src/etasl_example_controller.cpp
@@ -178,14 +178,14 @@ bool EtaslController::configureInput(ros::NodeHandle& node_handle)
       }
       else if (input_types_[i] == "Wrench")
       {
-	ROS_INFO_STREAM("EtaslController: Adding input channel \"" << input_names_[i] << "\" of type \"Twist\"");
-	wrench_input_names_.push_back(input_names_[i]);
-	auto input_buffer = boost::make_shared<realtime_tools::RealtimeBuffer<geometry_msgs::Wrench>>();
-	boost::function<void(const geometry_msgs::WrenchConstPtr&)> callback =
-	  [input_buffer](const geometry_msgs::WrenchConstPtr& msg) { input_buffer->writeFromNonRT(*msg); };
-	subs_.push_back(node-handle.subscribe<geometry_msgs::Wrench>(input_names_[i], 1, callback));
-	wrench_input_buffers_.push_back(input_buffer);
-	++n_wrench_inputs_;
+	      ROS_INFO_STREAM("EtaslController: Adding input channel \"" << input_names_[i] << "\" of type \"Twist\"");
+	      wrench_input_names_.push_back(input_names_[i]);
+	      auto input_buffer = boost::make_shared<realtime_tools::RealtimeBuffer<geometry_msgs::Wrench>>();
+	      boost::function<void(const geometry_msgs::WrenchConstPtr&)> callback =
+	          [input_buffer](const geometry_msgs::WrenchConstPtr& msg) { input_buffer->writeFromNonRT(*msg); };
+	      subs_.push_back(node_handle.subscribe<geometry_msgs::Wrench>(input_names_[i], 1, callback));
+	      wrench_input_buffers_.push_back(input_buffer);
+	      ++n_wrench_inputs_;
       }
       else
       {
@@ -262,7 +262,7 @@ void EtaslController::getInput()
     {
       Wrench wrench;
       tf::wrenchMsgToKDL(*wrench_input_buffers_[i]->readFromRT(), wrench);
-      wrench_input_map["global." + wrench_input_names_[i]] = wrench;
+      wrench_input_map_["global." + wrench_input_names_[i]] = wrench;
     }
     etasl_->setInput(wrench_input_map_);
   }

--- a/etasl_ros_controllers/src/topic_observer.cpp
+++ b/etasl_ros_controllers/src/topic_observer.cpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2019 Norwegian University of Science and Technology
+// Use of this source code is governed by the LGPL-3.0 license, see LICENSE
+
+/*
+ * Author: Mathias Hauan Arbo
+ *
+ * This file has been adapted from:
+ * https://gitlab.mech.kuleuven.be/rob-expressiongraphs/etasl_rtt/blob/master/src/port_observer.hpp
+ */
+#include "etasl_ros_controllers/topic_observer.h"
+
+namespace KDL
+{
+
+/**
+ * Observer that publishes events to a ROS topic
+ */
+
+class TopicObserver : public Observer
+{
+  Context::Ptr ctx;
+  const std::string portname;
+  Observer::Ptr next;                 ///< the next observer you want to react to monitors.
+  boost::shared_ptr<realtime_tools::RealtimePublisher<std_msgs::String>> outp;
+  const std::string action_name;
+  const std::string event_postfix;
+  bool exit_when_triggered;
+public:
+  typedef boost::shared_ptr<TopicObserver> Ptr;
+  TopicObserver(Context::Ptr _ctx,
+		boost::shared_ptr<realtime_tools::RealtimePublisher<std_msgs::String>> _outp,
+		const std::string& _action_name,
+		const std::string& _event_postfix,
+		bool _exit_when_triggered,
+		Observer::Ptr _next)
+    : ctx(_ctx), outp(_outp),
+      action_name(_action_name),
+      event_postfix(_event_postfix),
+      exit_when_triggered(_exit_when_triggered),
+      next(_next)
+  {}
+  
+  /**
+   * The solver will call this when MonitoringScalar is activated.
+   * \param [in] mon the monitor that was activated.
+   */
+  virtual void monitor_activated(const  MonitorScalar& mon)
+  {
+    std::string ename = mon.argument;
+    if (mon.action_name.compare(action_name)==0)
+    {
+      if (ename.size()==0)
+      {
+      	ename = "e_finished";
+      }
+      
+      if (event_postfix.size()!=0)
+      {
+	ename = ename + "@" + event_postfix;
+      }
+      if (outp->trylock())
+      {
+	outp->msg_.data = ename;
+	outp->unlockAndPublish();
+      }
+      if (exit_when_triggered)
+      {
+	ctx->setFinishStatus();
+      }
+    }
+    else
+    {
+      if (next)
+      {
+	next->monitor_activated(mon);
+      }
+    }
+  }
+  virtual ~TopicObserver() {}
+};
+
+Observer::Ptr create_topic_observer(
+    Context::Ptr _ctx,
+    boost::shared_ptr<realtime_tools::RealtimePublisher<std_msgs::String>> _outp,
+    const std::string& _action_name,
+    const std::string& _event_postfix,
+    bool  _exit_when_triggered,
+    Observer::Ptr _next)
+{
+  TopicObserver::Ptr r( new TopicObserver(_ctx, _outp, _action_name, _event_postfix, _exit_when_triggered, _next) );
+  return r;
+}
+
+}


### PR DESCRIPTION
Dag had begun on using event monitoring in his project, but it wasn't using the "observers" that Erwin had developed. In this pull-request I 
1. made a RealtimePublisher-based event observer
2. an example usage of it showing event and exit event 
3. made the etasl_example_controller stop commanding new positions if getFinishStatus
4. moved ctx_ to public, as it is in the etasl RTT component (necessary for setting up observers)